### PR TITLE
Add shadcn UI and artist shop query

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,103 +1,40 @@
-import Image from "next/image";
+import { useActionState } from "react"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import { getArtistShopUrls } from "@/lib/utils"
+
+interface State {
+  urls: string[]
+}
+
+async function queryAction(_: State, formData: FormData): Promise<State> {
+  'use server'
+  const query = formData.get('query')?.toString() || ''
+  if (!query) {
+    return { urls: [] }
+  }
+  const urls = await getArtistShopUrls(query)
+  return { urls }
+}
 
 export default function Home() {
-  return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="list-inside list-decimal text-sm/6 text-center sm:text-left font-[family-name:var(--font-geist-mono)]">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-[family-name:var(--font-geist-mono)] font-semibold">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
+  const [state, formAction] = useActionState(queryAction, { urls: [] })
 
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
-    </div>
-  );
+  return (
+    <main className="container mx-auto max-w-xl p-6 space-y-4">
+      <form action={formAction} className="flex gap-2">
+        <Input name="query" placeholder="Search artist" />
+        <Button type="submit">Query</Button>
+      </form>
+      <ul className="list-disc pl-5 space-y-1">
+        {state.urls.map((url) => (
+          <li key={url}>
+            <a href={url} className="underline" target="_blank" rel="noreferrer">
+              {url}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </main>
+  )
 }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,9 @@
+import * as React from "react"
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(({ type = "button", ...props }, ref) => {
+  return <button ref={ref} type={type} {...props} className="inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2" />
+})
+Button.displayName = "Button"
+export { Button }

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,9 @@
+import * as React from "react"
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(({ type, ...props }, ref) => {
+  return <input type={type} ref={ref} {...props} className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring" />
+})
+Input.displayName = "Input"
+export { Input }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,52 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+export interface Artist {
+  id: string
+  name: string
+}
 
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+async function getAccessToken(): Promise<string> {
+  const clientId = process.env.SPOTIPY_CLIENT_ID
+  const clientSecret = process.env.SPOTIPY_CLIENT_SECRET
+
+  if (!clientId || !clientSecret) {
+    throw new Error('Missing Spotify credentials')
+  }
+
+  const res = await fetch('https://accounts.spotify.com/api/token', {
+    method: 'POST',
+    headers: {
+      Authorization: `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`,
+      'Content-Type': 'application/x-www-form-urlencoded'
+    },
+    body: 'grant_type=client_credentials'
+  })
+
+  if (!res.ok) {
+    throw new Error('Failed to get token')
+  }
+
+  const data = await res.json()
+  return data.access_token as string
+}
+
+async function searchArtists(query: string, token: string): Promise<Artist[]> {
+  const res = await fetch(`https://api.spotify.com/v1/search?type=artist&q=${encodeURIComponent(query)}`, {
+    headers: { Authorization: `Bearer ${token}` }
+  })
+
+  if (!res.ok) {
+    throw new Error('Failed to search artists')
+  }
+
+  const data = await res.json()
+  return data.artists.items.map((a: any) => ({ id: a.id, name: a.name })) as Artist[]
+}
+
+function generateShopUrls(artists: Artist[]): string[] {
+  return artists.map(a => `https://open.spotify.com/artist/${a.id}/store`)
+}
+
+export async function getArtistShopUrls(query: string): Promise<string[]> {
+  const token = await getAccessToken()
+  const artists = await searchArtists(query, token)
+  return generateShopUrls(artists)
 }


### PR DESCRIPTION
## Summary
- add shadcn UI `Input` and `Button` components
- rewrite lib utils to fetch artist shop urls
- replace default home page with a form that queries shop URLs using a server action

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f5c4310708333a4859ebd0bfe728f